### PR TITLE
update authoring docs with second example of package.json

### DIFF
--- a/app/authoring/index.md
+++ b/app/authoring/index.md
@@ -82,6 +82,17 @@ The previous example can be written as follows:
         └───index.js
 ```
 
+If you use this second directory structure, make sure you point the `files` property in your `package.json` at the `generators` folder.
+
+```json
+{
+  "files": [
+    "generators/app",
+    "generators/router"
+  ]
+}
+```
+
 
 ## Extending generator
 


### PR DESCRIPTION
It mentions both directory structured, but only includes a single example of the `files` property.
Added an example for the second directory structure.