### PR TITLE
Fix table sorting of generators

### DIFF
--- a/app/assets/js/generator.js
+++ b/app/assets/js/generator.js
@@ -63,7 +63,7 @@
 
         var list = new List('plugins-all', {
           valueNames: [
-            'name',
+            'name-website',
             'stars',
             'updated',
             'installs'

--- a/app/generators/index.html
+++ b/app/generators/index.html
@@ -19,7 +19,7 @@ class: discovery-page
       </caption>
       <thead>
         <tr>
-          <th class="sort" data-sort="name">Generator</th>
+          <th class="sort" data-sort="name-website">Generator</th>
           <th class="sort metadata last-updated" data-sort="updated">Last Updated</th>
           <th class="sort metadata" data-sort="stars">Stars</th>
           <th class="sort metadata" data-sort="installs">Installs</th>
@@ -49,10 +49,10 @@ class: discovery-page
                 <% } %>
                 <span class="metadata">
                   <% if (el.updated) { %>
-                      <span>Last updated: <%- el.updated %> ago</span>
+                      <span class="updated">Last updated: <%- el.updated %> ago</span>
                   <% } %>
-                  <span><%- el.stars %></span>
-                  <span><%- el.downloads %></span>
+                  <span class="stars"><%- el.stars %></span>
+                  <span class="installs"><%- el.downloads %></span>
                 </span>
               </span>
               <br>


### PR DESCRIPTION
The table sorting seems broken again.
http://yeoman.io/generators/

This patch recovers sort feature, but the order of "last update" is not correct because [List.js](http://www.listjs.com/) sorts contents alphabetically. (e.g. "2 days ago" > "2 months ago" > "3 days ago")

Lits.js has a tricky [workaround](https://github.com/javve/list.js/issues/203#issuecomment-33517804) and  [feature request](https://github.com/javve/list.js/issues/35) to improve the data handling.

What do you think?
If the workaround is ok, I will update my PR to fix order.