### PR TITLE
authoring/user-interactions: remove banner field for argument’s hash

### DIFF
--- a/app/authoring/user-interactions.md
+++ b/app/authoring/user-interactions.md
@@ -79,7 +79,6 @@ The options hash accepts multiple key-value pairs:
 - `optional` Boolean whether it is optional
 - `type` String, Number, Array, or Object
 - `defaults` Default value for this argument
-- `banner` String to show on usage notes (this one is provided by default)
 
 This method must be called inside the `constructor` method. Otherwise Yeoman won't be able to output the relevant help information when a user calls your generator with the help option: e.g. `yo webapp --help`.
 


### PR DESCRIPTION
as far as there is no such option in the actual code https://github.com/yeoman/generator/blob/master/lib/base.js#L289-L295