### PR TITLE
Stretches the content container to always fill the screen

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -88,6 +88,11 @@ textarea {
 Author's custom styles
 ========================================================================== */
 
+body,
+html {
+  height: 100%;
+}
+
 html {
   font-family: 'Roboto', sans-serif;
 }
@@ -298,8 +303,14 @@ Navigation
 /* Content
 ========================================================================== */
 
+#content {
+  min-height: 100%;
+  margin-bottom: -162px;
+}
+
 .main {
   padding: 0 1.3em;
+  margin-bottom: 175px;
   font-size: 1em;
   line-height: 1.6;
 }
@@ -985,6 +996,10 @@ Modify as content requires.
 
 
 @media only screen and (min-width: 28em) {
+  #content {
+    margin-bottom: -175px;
+  }
+
   .jumbotron {
     padding-top: 5em;
   }
@@ -1089,6 +1104,10 @@ Modify as content requires.
 
 /* Menu gets to be displayed */
 @media only screen and (min-width: 46em) {
+  #content {
+    margin-bottom: -112px;
+  }
+
   .main-menu {
     position: relative;
     z-index: 13;


### PR DESCRIPTION
Resolves #566 by adjusting the styles to ensure the footer remains pushed to the bottom of the page. 

## Before

![before - style guide page](https://cloud.githubusercontent.com/assets/1934719/11176458/7e00837c-8bfa-11e5-9e2b-a73550a878b6.png)


## After

![after - style guide page](https://cloud.githubusercontent.com/assets/1934719/11176464/87d260dc-8bfa-11e5-9409-22931921d777.png)