### PR TITLE
Fixing the generator list displaying error

### DIFF
--- a/app/assets/js/generator.js
+++ b/app/assets/js/generator.js
@@ -50,6 +50,8 @@
         modules: modules
       });
 
+      $('#plugins-all').html(allTpl).find('.search').show();
+
       var list = new List('plugins-all', {
         valueNames: [
           'name-website',


### PR DESCRIPTION
Putting back the initialization of the '#plugin-all' element (in the generator list view) using its template.
A fix for the issue https://github.com/yeoman/yeoman.github.io/issues/580.

![image](https://cloud.githubusercontent.com/assets/1769608/11714095/e17c223a-9f37-11e5-8465-d39b87f749cd.png)
