### PR TITLE
Removed extra 'ago' from 'Last Updated' section in the generators table

### DIFF
--- a/app/generators/index.html
+++ b/app/generators/index.html
@@ -81,7 +81,7 @@ class: discovery-page
                   <%if el.updated %>
                     <span>Last updated:
                       <span class="updated hidden"><%= el.updated %></span>
-                      <%= el.timeSince %> ago
+                      <%= el.timeSince %>
                     </span>
                   <%if%>
                   <span class="stars"><%= el.stars %></span>


### PR DESCRIPTION
Two 'ago's appear in the table.