### PR TITLE
Added Jekyll Serve command to Readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,9 @@ npm install
 gem install bundler
 bundle install
 ```
+**3\.** Start dev server with Jekyll
+
+```jekyll serve```
 
 Now you're ready to do some work!
 


### PR DESCRIPTION
Jekyll Serve command was missing in the Readme and the next steps weren't clear. I had to do a lot of digging in the issues panel to find this.