### PR TITLE
Changed table structure in Generators List Page

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -749,6 +749,7 @@ li.L1,li.L3,li.L5,li.L7,li.L9 { }
   padding: 10px 5px;
   border-top: 1px solid #ddd;
   position: relative;
+  vertical-align: top;
 }
 
 .discovery-page tr.official td.generator-item::before {
@@ -769,23 +770,25 @@ li.L1,li.L3,li.L5,li.L7,li.L9 { }
 .discovery-page td.generator-item a:hover {
   text-decoration: underline;
 }
+.discovery-page .name-info .name{
+  font-size: larger;
+}
 .discovery-page .name-author {
   font-size: small;
   margin-left: 20px;
 }
-
-.discovery-page span.metadata {
-  font-size: 0.6em;
-  float: right;
+.discovery-page .description{
+  font-size:smaller;
 }
-.discovery-page span.metadata span {
-  display: inline-block;
-  margin-left: 50px;
+
+.discovery-page td.metadata {
+  font-size: smaller;
+  text-align:right;
 }
 
 .discovery-page th.metadata {
   font-size: 0.9em;
-  text-align: right;
+  text-align:right;
   width: 85px;
 }
 .discovery-page th.last-updated {

--- a/app/generators/index.html
+++ b/app/generators/index.html
@@ -56,9 +56,9 @@ class: discovery-page
         </tr>
       </thead>
       <tbody class="list">
-        <%each it.modules :el:index %>
+       <%each it.modules :el:index %>
           <tr class="<%if el.official %>official<%if%>">
-            <td class="generator-item" colspan="4">
+            <td class="generator-item">
               <span class="name-info">
                 <%if el.site %>
                   <a href="<%= el.site %>">
@@ -77,20 +77,20 @@ class: discovery-page
                     <%if%>
                   </span>
                 <%if%>
-                <span class="metadata">
-                  <%if el.updated %>
-                    <span>Last updated:
-                      <span class="updated hidden"><%= el.updated %></span>
-                      <%= el.timeSince %>
-                    </span>
-                  <%if%>
-                  <span class="stars"><%= el.stars %></span>
-                  <span class="downloads"><%= el.downloads %></span>
-                </span>
               </span>
               <br>
               <span class="description"><%= el.description %></span>
             </td>
+            <td class="updated metadata">
+                  <%if el.updated %>
+                    <span>
+                      <span class="hidden"><%= el.updated %></span>
+                      <%= el.timeSince %>
+                    </span>
+                  <%if%>
+            </td>
+            <td class="stars metadata"><%= el.stars %></td>
+            <td class="downloads metadata"><%= el.downloads %></td>
           </tr>
         <%each%>
       </tbody>


### PR DESCRIPTION
There were a couple of elements in the generator-listing page, which I felt could be improved. So, I tweaked the table a little bit and modified the styles. Let me know what you think. cc @hemanth 

## Before

<img width="1149" alt="screen shot 2015-12-23 at 5 51 57 pm" src="https://cloud.githubusercontent.com/assets/2936644/11976465/659b175e-a99e-11e5-9d70-f5accad55257.png">

## After
<img width="1151" alt="screen shot 2015-12-23 at 5 52 10 pm" src="https://cloud.githubusercontent.com/assets/2936644/11976468/67b069f4-a99e-11e5-8420-de856f95692a.png">

