### PR TITLE
Removing dead link in integrating-yeoman.md

### DIFF
--- a/app/authoring/integrating-yeoman.md
+++ b/app/authoring/integrating-yeoman.md
@@ -102,7 +102,7 @@ Yeoman uses _adapters_ as an abstraction layer to allow IDE, code editor and the
 
 An adapter is the object responsible for handling all the interaction with the user. If you want to provide a different interaction model from the classical command line, you have to write your own adapter. Every methods to interact with a user are passing through this adapter (mainly: prompting, logging and diffing).
 
-By default, Yeoman provide a [Terminal Adapter](https://github.com/yeoman/environment/blob/master/lib/adapter.js). And our test helpers provide a [Test Adapter](https://github.com/yeoman/generator/blob/master/lib/test/adapter.js) who's mocking prompts and silencing the output. These are two good examples you can use as reference.
+By default, Yeoman provides a [Terminal Adapter](https://github.com/yeoman/environment/blob/master/lib/adapter.js). Take this as a reference for your own implementation.
 
 An adapter should provide at least three methods.
 


### PR DESCRIPTION
Removed link to the TestAdapter as it is no longer present.