### PR TITLE
Remove scoped variables section

### DIFF
--- a/app/contributing/testing-guidelines.md
+++ b/app/contributing/testing-guidelines.md
@@ -99,20 +99,3 @@ assert.throws(function () {
 assert.throws(class.method.bind(class, 'Invalid param'));
 ```
 
-#### Never use scoped variables
-
-When creating test variables, always attach them to the `this` context. You're guaranteed that `this` is a totally new object each time a test is run. By comparison, scoped variables can easily leak values and have side effects between tests.
-
-```javascript
-describe('my module', function () {
-  var foo;
-
-  beforeEach(function () {
-    // BAD
-    foo = 1;
-
-    // GOOD
-    this.foo = '1';
-  });
-});
-```


### PR DESCRIPTION
One of the claims here is false:

> "You're guaranteed that `this` is a totally new object each time a test is run."

This feature exists in jasmine, but not mocha. In mocha, the "this" context **does not** get cleared out for each test run, but in fact sticks around for an entire suite. This can cause pollution itself, since variables can now travel outside of their scope. E.g.:

```
describe('mySuite', function() {
	describe('myComponent', function() {
		beforeEach(function() {
			this.controller = foo
		});

		it('does something', function() {
			this.controller.doSomething();
		});
	});
	
	it('does something else', function() {
		this.controller // => foo 
	});
});
```

I deleted the section because I don't think there's a simple way to explain this quirk. Maybe it makes sense to just add "if you're using jasmine.js..."