### PR TITLE
Link to practical composability example

### DIFF
--- a/app/authoring/composability.md
+++ b/app/authoring/composability.md
@@ -99,6 +99,11 @@ writing - zap
 
 However, you can alter this by switching the calls for `this.composeWith`, also keep in mind, these can be generators from npm packages, see below.
 
+For a more complex example of composability, check out
+[generator-generator](https://github.com/yeoman/generator-generator/blob/master/app/index.js)
+which is composed of
+[generator-node](https://github.com/yeoman/generator-node).
+
 ## dependencies or peerDependencies
 
 *npm* allows three types of dependencies:


### PR DESCRIPTION
I got quite confused by just the docs as they are, trying to implement my own generator that composes another generator. After finding this example generator-generator <- generator-node, I discovered some nice tricks in it, like how to actually pass the `skipInstall` option (that the dashed-name is magically converted to camelCase), that the `composeWith` method should be placed inside the `default` group etc. I think a link to such a maintained complex example would be useful to people reading the docs.