### PR TITLE
Update debugging.md

### DIFF
--- a/app/authoring/debugging.md
+++ b/app/authoring/debugging.md
@@ -15,9 +15,10 @@ node --debug `which yo` <generator> [arguments]
 # Windows
 # Find the path to the yo binary
 where yo
-
-# Use this path to run it with the debug flag
-node --debug <path to yo binary> <generator> [arguments]
+# Would be something like C:\Users\<USER>\AppData\Roaming\npm\yo
+# Use this path to derive yo cli.js file
+# C:\Users\<USER>\AppData\Roaming\npm\node_modules\yo\lib\cli.js
+node --debug <path to yo cli.js> <generator> [arguments]
 ```
 
 Yeoman generators also provide a debug mode to log relevant lifecycle information. You can activate it by setting the `DEBUG` environment variable to the desired scope (the scope of the generator system is `yeoman:generator`).


### PR DESCRIPTION
In window, running node --debug from yo binary file gives an undefined basedir error.
you have to execute yo cli.js file from node for it to properly work
source: http://techblog.dorogin.com/2014/04/how-to-debug-yeoman-generator.html