### PR TITLE
Add PowerShell version of the Windows instructions

### DIFF
--- a/app/authoring/debugging.md
+++ b/app/authoring/debugging.md
@@ -13,8 +13,10 @@ To debug a generator, you can pass Node.js debug flags by running it like this:
 node --debug `which yo` <generator> [arguments]
 
 # Windows
-# Find the path to the yo binary
+# Find the path to the yo binary in Command Prompt
 where yo
+# Or find the path to the yo binary in PowerShell
+get-command yo
 # Would be something like C:\Users\<USER>\AppData\Roaming\npm\yo
 # Use this path to derive yo cli.js file
 # C:\Users\<USER>\AppData\Roaming\npm\node_modules\yo\lib\cli.js


### PR DESCRIPTION
Hopefully more Windows developers are using PowerShell than Command Prompt, and this will help them out since "where" is actually a command for filtering data passed into it.