### PR TITLE
Fix npm options example

### DIFF
--- a/app/authoring/dependencies.md
+++ b/app/authoring/dependencies.md
@@ -21,7 +21,7 @@ For example you want to install lodash as a dev dependency:
 ```js
 generators.Base.extend({
   installingLodash: function() {
-    this.npmInstall(['lodash'], { 'saveDev': true });
+    this.npmInstall(['lodash'], { 'save-dev': true });
   }
 });
 ```


### PR DESCRIPTION
Closes yeoman/generator#933

I tested both actually.

```
installingLodash: function() {
  this.npmInstall(['lodash'], { 'saveDev': true });
}
```

VS.

```
installingLodash: function() {
  this.npmInstall(['lodash'], { 'save-dev': true });
}
```

They worked both with npm `v3.10.8`. 

