### PR TITLE
Add documentation for Execution context

### DIFF
--- a/app/authoring/file-system.md
+++ b/app/authoring/file-system.md
@@ -8,7 +8,7 @@ excerpt: How to interact with the file system in efficient ways
 
 ## Location contexts and paths
 
-Yeoman file utilities are based on the idea you always have three location contexts on disk. These contexts are folders your generator will most likely read from and write to.
+Yeoman file utilities are based on the idea you always have two location contexts on disk. These contexts are folders your generator will most likely read from and write to.
 
 ### Destination context
 
@@ -33,6 +33,15 @@ class extends Generator {
 
 And you can manually set it using `generator.destinationRoot('new/path')`. But for consistency, you probably shouldn't change the default destination.
 
+Note that you can use the `contextRoot` property of the generator to retrieve the directory in which Yeoman is being executed:
+
+```js
+var currentDirectory = this.contextRoot ;
+// do something into the folder where Yeoman is being executed
+```
+
+It is useful if your generator needs to scaffold into _that_ directory instead of the _destination context_.
+
 ### Template context
 
 The template context is the folder in which you store your template files. It is usually the folder from which you'll read and copy.
@@ -51,17 +60,6 @@ class extends Generator {
     // returns './templates/index.js'
   }
 });
-```
-
-### Execution context
-
-The execution context is the folder in which Yeoman is being executed. It is useful if your generator needs to scaffold into _that_ folder instead of the _destination context_ - which may point to your user project folder.
-
-You can get the execution context by retrieving the value of the `contextRoot` property of the generator:
-
-```js
-var contextRoot = this.contextRoot ;
-// do something into the folder where Yeoman is being executed
 ```
 
 ## An "in memory" file system

--- a/app/authoring/file-system.md
+++ b/app/authoring/file-system.md
@@ -8,7 +8,7 @@ excerpt: How to interact with the file system in efficient ways
 
 ## Location contexts and paths
 
-Yeoman file utilities are based on the idea you always have two location contexts on disk. These contexts are folders your generator will most likely read from and write to.
+Yeoman file utilities are based on the idea you always have three location contexts on disk. These contexts are folders your generator will most likely read from and write to.
 
 ### Destination context
 
@@ -51,6 +51,17 @@ class extends Generator {
     // returns './templates/index.js'
   }
 });
+```
+
+### Execution context
+
+The execution context is the folder in which Yeoman is being executed. It is useful if your generator needs to scaffold into _that_ folder instead of the _destination context_ - which may point to your user project folder.
+
+You can get the execution context by retrieving the value of the `contextRoot` property of the generator:
+
+```js
+var contextRoot = this.contextRoot ;
+// do something into the folder where Yeoman is being executed
 ```
 
 ## An "in memory" file system


### PR DESCRIPTION
This PR adds documentation for the execution context as added by the PR yeoman/generator/pull/982 - _Expose the directory where the generator is being executed_.