### PR TITLE
Changed build to gulp build

### DIFF
--- a/app/learning/deployment.md
+++ b/app/learning/deployment.md
@@ -5,7 +5,7 @@ title: Deploying a Yeoman Site
 sidebar: sidebars/learning.md
 ---
 
-Running the `build` task generates an optimized version of your application in the `dist` directory. There are multiple ways to version and deploy this code to production.
+Running the `gulp build` task generates an optimized version of your application in the `dist` directory. There are multiple ways to version and deploy this code to production.
 
 ## Gulp-gh-pages
 


### PR DESCRIPTION
I had trouble finding the `build` task, until I realised it was a `gulp` task. Made it clearer.

New to Yeoman, so if `gulp build` is only used sometimes, feel free to close & ignore.