### PR TITLE
Fix link to `package.json` documentation

### DIFF
--- a/app/authoring/index.md
+++ b/app/authoring/index.md
@@ -46,7 +46,7 @@ You should make sure you set the latest version of `yeoman-generator` as a depen
 
 The `files` property must be an array of files and directories that is used by your generator.
 
-Add other [`package.json` properties](https://docs.npmjs.com/files/package.json#files) as needed.
+Add other [`package.json` properties](https://docs.npmjs.com/files/package.json) as needed.
 
 ### Folder tree
 


### PR DESCRIPTION
In the context of this sentence, I don’t think it makes much sense to link directly to the documentation of the `files` property.