### PR TITLE
Get rid of erroneous parenthesis at the end of source extends for sourceRoot example

### DIFF
--- a/app/authoring/file-system.md
+++ b/app/authoring/file-system.md
@@ -52,7 +52,7 @@ class extends Generator {
     this.templatePath('index.js');
     // returns './templates/index.js'
   }
-});
+};
 ```
 
 ## An "in memory" file system


### PR DESCRIPTION
…rceRoot example