### PR TITLE
Fixed property name beautify listing

### DIFF
--- a/app/authoring/file-system.md
+++ b/app/authoring/file-system.md
@@ -119,7 +119,7 @@ Registering a new modifier is done through the `registerTransformStream()` metho
 
 ```js
 var beautify = require('gulp-beautify');
-this.registerTransformStream(beautify({indentSize: 2 }));
+this.registerTransformStream(beautify({indent_size: 2 }));
 ```
 
 Note that **every file of any type will be passed through this stream**. Make sure any transform stream will passthrough the files it doesn't support. Tools like [gulp-if](https://github.com/robrich/gulp-if) or [gulp-filter](https://github.com/sindresorhus/gulp-filter) will help filter invalid types and pass them through.


### PR DESCRIPTION
If you look at [`gulp-beautify` README](https://www.npmjs.com/package/gulp-beautify) it expects `indent_size` rather than `indentSize`.