### PR TITLE
Update Install prerequisites

### DIFF
--- a/app/codelab/setup.md
+++ b/app/codelab/setup.md
@@ -12,11 +12,10 @@ Most of your interactions with Yeoman will be through the command line. Run comm
 
 ## Install prerequisites
 
-Before installing Yeoman, you will need the following:
-
-* Node.js v4 or higher
-* npm (which comes bundled with Node)
-* git
+Before installing the Fountain Webapp Generator, you will need the following:
+* Node.js v6.0.0 or higher
+* NPM v3.0.0 or higher (which comes bundled with Node)
+* Git
 
 You can check if you have Node and npm installed by typing:
 

--- a/app/codelab/setup.md
+++ b/app/codelab/setup.md
@@ -13,8 +13,8 @@ Most of your interactions with Yeoman will be through the command line. Run comm
 ## Install prerequisites
 
 Before installing the Fountain Webapp Generator, you will need the following:
-* Node.js v6.0.0 or higher
-* NPM v3.0.0 or higher (which comes bundled with Node)
+* Node.js 6 or higher
+* npm 3 or higher (which comes bundled with Node)
 * Git
 
 You can check if you have Node and npm installed by typing:


### PR DESCRIPTION
Update the install prerequisites section, as while Yeoman only requires Node.js >= v4, the Fountain Webapp Generator [requires v6.0.0 or higher](https://github.com/FountainJS/generator-fountain-webapp#requirement-node-6--npm-3).