### PR TITLE
Minor capitalisation fix

### DIFF
--- a/app/authoring/user-interactions.md
+++ b/app/authoring/user-interactions.md
@@ -52,7 +52,7 @@ Yeoman extends the Inquirer.js API by adding a `store` property to question obje
 this.prompt({
   type    : 'input',
   name    : 'username',
-  message : 'What\'s your Github username',
+  message : 'What\'s your GitHub username',
   store   : true
 });
 ```


### PR DESCRIPTION
GitHub uses a capital 'H':

![screen shot 2017-05-18 at 10 36 43](https://cloud.githubusercontent.com/assets/49038/26196161/fa47fb1a-3bb5-11e7-978f-29c4af682648.png)
