### PR TITLE
Corrected 'is running' to 'is run' on line 13

### DIFF
--- a/app/authoring/running-context.md
+++ b/app/authoring/running-context.md
@@ -10,7 +10,7 @@ One of the most important concepts to grasp when writing a Generator is how meth
 
 ## Prototype methods as actions
 
-Each method directly attached to a Generator prototype is considered to be a task. Each task is running in sequence by the Yeoman environment run loop.
+Each method directly attached to a Generator prototype is considered to be a task. Each task is run in sequence by the Yeoman environment run loop.
 
 In other words, each function on the object returned by `Object.getPrototypeOf(Generator)` will be automatically run.
 


### PR DESCRIPTION
This is the wrong tense and doesn't work, grammatically: 'Each task is running in sequence by the Yeoman environment run loop.'