### PR TITLE
Suggest node --inspect for debugging

### DIFF
--- a/app/authoring/debugging.md
+++ b/app/authoring/debugging.md
@@ -10,7 +10,7 @@ To debug a generator, you can pass Node.js debug flags by running it like this:
 
 ```sh
 # OS X / Linux
-node --debug `which yo` <generator> [arguments]
+node --inspect `which yo` <generator> [arguments]
 
 # Windows
 # Find the path to the yo binary in Command Prompt
@@ -20,8 +20,10 @@ get-command yo
 # Would be something like C:\Users\<USER>\AppData\Roaming\npm\yo
 # Use this path to derive yo cli.js file
 # C:\Users\<USER>\AppData\Roaming\npm\node_modules\yo\lib\cli.js
-node --debug <path to yo cli.js> <generator> [arguments]
+node --inspect <path to yo cli.js> <generator> [arguments]
 ```
+
+You can then debug your generator using the Chrome Devtools or your preferred IDE. See https://nodejs.org/en/docs/inspector/ for more info.
 
 Yeoman generators also provide a debug mode to log relevant lifecycle information. You can activate it by setting the `DEBUG` environment variable to the desired scope (the scope of the generator system is `yeoman:generator`).
 


### PR DESCRIPTION
`node --inspect` is a great alternative to `node --debug`, suggest using
it.

TBH since `node --inspect` became a thing (Node 6.x) I haven't used
`node --debug`, and I suspect that's true for a lot of people. I think
ideally we'd suggest `node --inspect`, and offer `node --debug` as a
backup.

If I messed up something about the PR let me know!