### PR TITLE
Fix mixed content error when serving via https

### DIFF
--- a/app/_includes/foot.html
+++ b/app/_includes/foot.html
@@ -64,7 +64,7 @@
     ['_setDomainName', '.yeoman.io'],
     ['_trackPageview'],['_trackPageLoadTime']
   ];
-  $script('http://www.google-analytics.com/ga.js');
+  $script('https://www.google-analytics.com/ga.js');
   $script('https://apis.google.com/js/plusone.js');
   $script("//platform.twitter.com/widgets.js");
 </script>


### PR DESCRIPTION
That’s it. 

Closing #744 and related to #529.