### PR TITLE
moving `helpers.run` from `beforeEach` to `it`

### DIFF
--- a/app/authoring/testing.md
+++ b/app/authoring/testing.md
@@ -46,7 +46,7 @@ var path = require('path');
 
 it('generate a project', function () {
   // The object returned acts like a promise, so return it to wait until the process is done
-  helpers.run(path.join(__dirname, '../app'))
+  return helpers.run(path.join(__dirname, '../app'))
     .withOptions({ foo: 'bar' })      // Mock options passed in
     .withArguments(['name-x'])        // Mock the arguments
     .withPrompts({ coffee: false })   // Mock the prompt answers

--- a/app/authoring/testing.md
+++ b/app/authoring/testing.md
@@ -44,9 +44,9 @@ The most useful method when unit testing a generator is `helpers.run()`. This me
 ```js
 var path = require('path');
 
-beforeEach(function () {
+it("generate a project", function () {
   // The object returned acts like a promise, so return it to wait until the process is done
-  return helpers.run(path.join(__dirname, '../app'))
+  helpers.run(path.join(__dirname, '../app'))
     .withOptions({ foo: 'bar' })      // Mock options passed in
     .withArguments(['name-x'])        // Mock the arguments
     .withPrompts({ coffee: false })   // Mock the prompt answers

--- a/app/authoring/testing.md
+++ b/app/authoring/testing.md
@@ -44,13 +44,16 @@ The most useful method when unit testing a generator is `helpers.run()`. This me
 ```js
 var path = require('path');
 
-it("generate a project", function () {
+it('generate a project', function () {
   // The object returned acts like a promise, so return it to wait until the process is done
   helpers.run(path.join(__dirname, '../app'))
     .withOptions({ foo: 'bar' })      // Mock options passed in
     .withArguments(['name-x'])        // Mock the arguments
     .withPrompts({ coffee: false })   // Mock the prompt answers
-    .withLocalConfig({ lang: 'en' }); // Mock the local config
+    .withLocalConfig({ lang: 'en' }) // Mock the local config
+    .then(function() {
+      // assert something about the generator
+    });
 })
 ```
 


### PR DESCRIPTION
As there is no way to access the `generator` (not that i know of) created in `beforeEach` in `it` to write the test cases, example should show `run` method in `it`.