### PR TITLE
Add managing dependencies as package.json

### DIFF
--- a/app/authoring/dependencies.md
+++ b/app/authoring/dependencies.md
@@ -41,27 +41,25 @@ You can programatically create or extend your `package.json` file if you don’t
 Example defining `eslint` as dev dependency and `react` as dependency:
 
 ```js
- writing() {
-    const pkgJson = {
-        devDependencies: {
-            eslint: "^3.15.0"
-        },
-        dependencies: {
-            react: "^16.2.0",
-        },
+class extends Generator {
+	writing() {
+		const pkgJson = {
+			devDependencies: {
+				eslint: '^3.15.0'
+			},
+			dependencies: {
+				react: '^16.2.0'
+			}
+		};
 
-    };
-        
-    // Extend or create package.json file in destination path with pkgJson content
-    this.fs.extendJSON(
-      this.destinationPath('package.json'),
-      pkgJson
-    );
-  }
+		// Extend or create package.json file in destination path with pkgJson content
+		this.fs.extendJSON(this.destinationPath('package.json'), pkgJson);
+	}
 
-  install() {
-    this.npmInstall();
-  }
+	install() {
+		this.npmInstall();
+	}
+};
 ```
 
 ## Yarn

--- a/app/authoring/dependencies.md
+++ b/app/authoring/dependencies.md
@@ -52,7 +52,7 @@ class extends Generator {
       }
     };
 
-    // Extend or create package.json file in destination path with pkgJson content
+    // Extend or create package.json file in destination path
     this.fs.extendJSON(this.destinationPath('package.json'), pkgJson);
   }
 

--- a/app/authoring/dependencies.md
+++ b/app/authoring/dependencies.md
@@ -94,3 +94,34 @@ class extends Generator {
 ```
 
 Make sure to call the `spawnCommand` method inside the `install` queue. Your users don't want to wait for an installation command to complete.
+
+## Manage dependencies with `package.json`
+
+You just need to create a variable as same as `package.json` file. `fs` module can read and write it to destination folder as a `package.json` file. `npmInstall` function install all dependencies and dev dependencies.
+
+For example you want to install `eslint` as dev dependency and `react` as dependency. 
+
+```js
+ writing() {
+    const pkgJson = {
+        devDependencies: {
+            eslint: "^3.15.0"
+        },
+        dependencies: {
+            react: "^16.2.0",
+        },
+
+    };
+    // Create package.json file in destination path with pkgJson content
+    this.fs.extendJSON(
+      this.destinationPath('package.json'),
+      pkgJson
+    );
+  }
+
+  install() {
+    this.npmInstall();
+  }
+```
+
+This is equvalent to call `npm install` on created `package.json` file.

--- a/app/authoring/dependencies.md
+++ b/app/authoring/dependencies.md
@@ -42,23 +42,23 @@ Example defining `eslint` as dev dependency and `react` as dependency:
 
 ```js
 class extends Generator {
-	writing() {
-		const pkgJson = {
-			devDependencies: {
-				eslint: '^3.15.0'
-			},
-			dependencies: {
-				react: '^16.2.0'
-			}
-		};
+  writing() {
+    const pkgJson = {
+      devDependencies: {
+        eslint: '^3.15.0'
+      },
+      dependencies: {
+        react: '^16.2.0'
+      }
+    };
 
-		// Extend or create package.json file in destination path with pkgJson content
-		this.fs.extendJSON(this.destinationPath('package.json'), pkgJson);
-	}
+    // Extend or create package.json file in destination path with pkgJson content
+    this.fs.extendJSON(this.destinationPath('package.json'), pkgJson);
+  }
 
-	install() {
-		this.npmInstall();
-	}
+  install() {
+    this.npmInstall();
+  }
 };
 ```
 

--- a/app/authoring/dependencies.md
+++ b/app/authoring/dependencies.md
@@ -34,6 +34,35 @@ npm install lodash --save-dev
 
 on the command line in your project.
 
+### Manage npm dependencies programmatically
+
+You can programatically create or extend your `package.json` file if you don’t want to use a template but like to have fixed versions. Yeomans file system tools can help to get this job done..
+
+Example defining `eslint` as dev dependency and `react` as dependency:
+
+```js
+ writing() {
+    const pkgJson = {
+        devDependencies: {
+            eslint: "^3.15.0"
+        },
+        dependencies: {
+            react: "^16.2.0",
+        },
+
+    };
+    
+    // Create package.json file in destination path with pkgJson content
+    this.fs.extendJSON(
+      this.destinationPath('package.json'),
+      pkgJson
+    );
+  }
+
+  install() {
+    this.npmInstall();
+  }
+```
 
 ## Yarn
 
@@ -94,34 +123,3 @@ class extends Generator {
 ```
 
 Make sure to call the `spawnCommand` method inside the `install` queue. Your users don't want to wait for an installation command to complete.
-
-## Manage dependencies as `package.json`
-
-You just need to create a variable as same as `package.json` file. `fs` module can read and write it to destination folder as a `package.json` file. `npmInstall` function install all dependencies and dev dependencies.
-
-For example you want to install `eslint` as dev dependency and `react` as dependency. 
-
-```js
- writing() {
-    const pkgJson = {
-        devDependencies: {
-            eslint: "^3.15.0"
-        },
-        dependencies: {
-            react: "^16.2.0",
-        },
-
-    };
-    // Create package.json file in destination path with pkgJson content
-    this.fs.extendJSON(
-      this.destinationPath('package.json'),
-      pkgJson
-    );
-  }
-
-  install() {
-    this.npmInstall();
-  }
-```
-
-This is equvalent to call `npm install` on created `package.json` file.

--- a/app/authoring/dependencies.md
+++ b/app/authoring/dependencies.md
@@ -36,7 +36,7 @@ on the command line in your project.
 
 ### Manage npm dependencies programmatically
 
-You can programatically create or extend your `package.json` file if you don’t want to use a template but like to have fixed versions. Yeomans file system tools can help to get this job done..
+You can programatically create or extend your `package.json` file if you don’t want to use a template but like to have fixed versions. Yeomans file system tools can help to get this job done.
 
 Example defining `eslint` as dev dependency and `react` as dependency:
 
@@ -52,7 +52,12 @@ Example defining `eslint` as dev dependency and `react` as dependency:
 
     };
     
-    // Create package.json file in destination path with pkgJson content
+    this.fs.copy(
+			this.templatePath('package.json'),
+			this.destinationPath('package.json')
+		);
+    
+    // Extend package.json file in destination path with pkgJson content
     this.fs.extendJSON(
       this.destinationPath('package.json'),
       pkgJson

--- a/app/authoring/dependencies.md
+++ b/app/authoring/dependencies.md
@@ -95,7 +95,7 @@ class extends Generator {
 
 Make sure to call the `spawnCommand` method inside the `install` queue. Your users don't want to wait for an installation command to complete.
 
-## Manage dependencies with `package.json`
+## Manage dependencies as `package.json`
 
 You just need to create a variable as same as `package.json` file. `fs` module can read and write it to destination folder as a `package.json` file. `npmInstall` function install all dependencies and dev dependencies.
 

--- a/app/authoring/dependencies.md
+++ b/app/authoring/dependencies.md
@@ -36,7 +36,7 @@ on the command line in your project.
 
 ### Manage npm dependencies programmatically
 
-You can programatically create or extend your `package.json` file if you don’t want to use a template but like to have fixed versions. Yeomans file system tools can help to get this job done.
+You can programatically create or extend your `package.json` file if you don’t want to use a template but like to have fixed versions of your dependencies. Yeomans file system tools can help you to get this job done.
 
 Example defining `eslint` as dev dependency and `react` as dependency:
 
@@ -51,13 +51,8 @@ Example defining `eslint` as dev dependency and `react` as dependency:
         },
 
     };
-    
-    this.fs.copy(
-			this.templatePath('package.json'),
-			this.destinationPath('package.json')
-		);
-    
-    // Extend package.json file in destination path with pkgJson content
+        
+    // Extend or create package.json file in destination path with pkgJson content
     this.fs.extendJSON(
       this.destinationPath('package.json'),
       pkgJson


### PR DESCRIPTION
I explain how to manage dependencies as what we used to do at `package.json`. This method is used at `generator-node/generators/eslint/index.js`. I consider it can be useful if it explains in documentation. 