### PR TITLE
Fix deployment via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 branches:
   only:
     - source
+    - fix-travis
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
 branches:
   only:
     - source
-    - fix-travis
 
 addons:
   apt:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,7 +71,8 @@ module.exports = function (grunt) {
       },
       check: {
         options: {
-          doctor: true
+          doctor: true,
+          src: './'
         }
       }
     },


### PR DESCRIPTION
bundle exec jekyll doctor --source app didn’t worked because the app directory is missing a jekyll config file.