### PR TITLE
Fix Jekyll deprecation warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,13 +20,9 @@ show_drafts: true
 
 permalink: /blog/:title.html
 
-# Markdown library
-markdown: kramdown
-
-highlighter: rouge
-
 paginate: 8
 paginate_path: /blog/page:num
 
-gems:
+plugins:
+- jekyll-paginate
 - jekyll-redirect-from


### PR DESCRIPTION
Fix https://travis-ci.org/yeoman/yeoman.github.io/builds/369319754#L1045

- `gems` is now `plugins`
-  list `jekyll-paginate` in `plugins`
- `kramdown` and `rouge` are already the default